### PR TITLE
Avoid socket open at each request server -> client

### DIFF
--- a/client/resourceServer.js
+++ b/client/resourceServer.js
@@ -55,7 +55,7 @@ function startResourceServer(port = 56830) {
       return handleCreateRequest(req, res, { objectId, instanceId });
     }
 
-    $.logger.info("get resource:",objectId,instanceId,resourceId);
+    $.logger.debug(`get resource: ${objectId}/${instanceId}/${resourceId}`);
     const resource = getResource(objectId, instanceId, resourceId);
 
     if (!resource) {

--- a/client/transport/coapServer.js
+++ b/client/transport/coapServer.js
@@ -13,6 +13,7 @@ function createServer(handler, port = 56830) {
   return server;
 }
 
+// Notifications are being sent to server lwm2m default port
 function sendNotification(observer, path, value) {
   if (!$.client.registered) return;
 

--- a/server/clientRegistry.js
+++ b/server/clientRegistry.js
@@ -28,6 +28,11 @@ function deregisterClientByLocation(locationPath) {
   return null;
 }
 
+function associateSocketToClient(ep, socket){
+  let client = getClient(ep);
+  clients.set(ep,{ ...client, socket });
+}
+
 function listClients() {
   const result = [];
   for (const [ep, info] of clients.entries()) {
@@ -41,5 +46,6 @@ module.exports = {
   updateClient,
   getClient,
   deregisterClientByLocation,
+  associateSocketToClient,
   listClients,
 };

--- a/server/examples/dtlsServer.js
+++ b/server/examples/dtlsServer.js
@@ -72,32 +72,30 @@ function identityPskCallback(identity, sessionId) {
 async function getInfo(clientEp) {
   // Delay to wait for client registration
 
-  setTimeout(() => {
+  setTimeout(async () => {
     const client = clientEp;
     //console.log(`sending requests to client: ${client}`)
 
     try{
       /*
       // Read
-      discoveryRequest(clientEp)
-    
-      getRequest(clientEp,'/3/0/0')
-
+      await discoveryRequest(clientEp)
       */
-      //getRequest(clientEp,'/3303/0/5601')
+    
+      await getRequest(clientEp,'/3/0/0')
+
+      await getRequest(clientEp,'/3303/0/5601')
 
       // Observe timestamp
-      startObserveRequest(clientEp,'/6/0/7');
+      await startObserveRequest(clientEp,'/6/0/7');
 
       // Observe Temperature
-      startObserveRequest(clientEp,'/3303/0/5700');
+      await startObserveRequest(clientEp,'/3303/0/5700');
 
-      /*
-      // Write
       setTimeout(() => putRequest(clientEp,'/3303/0/5601', "-30.0"), 2000);
 
       setTimeout(() => getRequest(clientEp,'/3303/0/5601'), 3000);
-      */
+      
     }catch(error){
       console.error(error);
     }
@@ -105,9 +103,6 @@ async function getInfo(clientEp) {
     //setTimeout(() => sendCoapRequest(client, 'POST', '/3/0/2'), 9000);
   }, 2000);
 
-  /*
-    This doesn't work, client is set to undefined!!
-    Investigate it..
   setTimeout(() => {
     const client = clientEp;
     try{
@@ -116,7 +111,6 @@ async function getInfo(clientEp) {
       console.error(error);
     }
   }, 10000);
-  */
 }
 
 // Listen for registration events

--- a/server/examples/server.js
+++ b/server/examples/server.js
@@ -39,7 +39,7 @@ async function getInfo(clientEp) {
       getRequest(clientEp,'/3303/0/5601')
 
       // Observe timestamp
-      //startObserveRequest(clientEp,'/6/0/7');
+      startObserveRequest(clientEp,'/6/0/7');
 
       // Observe Temperature
       startObserveRequest(clientEp,'/3303/0/5700');
@@ -55,9 +55,6 @@ async function getInfo(clientEp) {
     //setTimeout(() => sendCoapRequest(client, 'POST', '/3/0/2'), 9000);
   }, 2000);
 
-  /*
-    This doesn't work, client is set to undefined!!
-    Investigate it..
   setTimeout(() => {
     const client = clientEp;
     try{
@@ -66,7 +63,6 @@ async function getInfo(clientEp) {
       console.error(error);
     }
   }, 10000);
-  */
 }
 
 // Listen for registration events

--- a/server/examples/serverMqttGw.js
+++ b/server/examples/serverMqttGw.js
@@ -42,23 +42,23 @@ process.on('unhandledRejection', (reason, promise) => {
 async function getInfo(clientEp) {
   // Delay to wait for client registration
 
-  setTimeout(() => {
+  setTimeout(async () => {
     const client = clientEp;
     //console.log(`sending requests to client: ${client}`)
 
     try{
       // Read
-      discoveryRequest(clientEp)
+      await discoveryRequest(clientEp)
 
-      getRequest(clientEp,'/3/0/0')
+      await getRequest(clientEp,'/3/0/0')
 
-      getRequest(clientEp,'/3303/0/5601')
+      await getRequest(clientEp,'/3303/0/5601')
 
       // Observe timestamp
-      //startObserveRequest(clientEp,'/6/0/7');
+      await startObserveRequest(clientEp,'/6/0/7');
 
       // Observe Temperature
-      startObserveRequest(clientEp,'/3303/0/5700');
+      await startObserveRequest(clientEp,'/3303/0/5700');
 
       // Write
       setTimeout(() => putRequest(clientEp,'/3303/0/5601', "-30.0"), 2000);
@@ -71,9 +71,6 @@ async function getInfo(clientEp) {
     //setTimeout(() => sendCoapRequest(client, 'POST', '/3/0/2'), 9000);
   }, 2000);
 
-  /*
-    This doesn't work, client is set to undefined!!
-    Investigate it..
   setTimeout(() => {
     const client = clientEp;
     try{
@@ -82,7 +79,6 @@ async function getInfo(clientEp) {
       console.error(error);
     }
   }, 10000);
-  */
 }
 
 if($.config?.mqttGw?.enabled){

--- a/server/observationRegistry.js
+++ b/server/observationRegistry.js
@@ -1,6 +1,6 @@
 // server/ObservationRegistry.js
 
-const registry = new Map(); // token -> { ep, path, format }
+const registry = new Map(); // token -> { ep, path, format, socket }
 
 /**
  * Registers a token observation and associates it with a client (ep), path, and format.
@@ -8,14 +8,15 @@ const registry = new Map(); // token -> { ep, path, format }
  * @param {string} ep - Endpoint of the client.
  * @param {string} path - Path of the resource being observed.
  * @param {string} format - Format of the observation (e.g., text, json, cbor, tlv).
+ * @param {Object} socket - Optional DTLS socket for cleanup.
  */
-function registerObservation(token, ep, path, format) {
+function registerObservation(token, ep, path, format, socket = null) {
   if (!token || !ep || !path || !format) {
     throw new Error('Token, endpoint (ep), path, and format are required to register an observation.');
   }
 
   const tokenKey = token.toString('hex'); // Convert token to a hex string for consistent storage
-  registry.set(tokenKey, { ep, path, format });
+  registry.set(tokenKey, { ep, path, format, socket });
   return true;
 }
 
@@ -34,7 +35,7 @@ function getObservation(token) {
 }
 
 /**
- * Deregisters an observation associated with a given token.
+ * Deregisters an observation associated with a given token and closes its socket if present.
  * @param {Buffer|string} token - Unique token for the observation.
  * @returns {boolean} True if the observation was removed, false if not found.
  */
@@ -44,11 +45,39 @@ function deregisterObservation(token) {
   }
 
   const tokenKey = token.toString('hex'); // Convert token to a hex string
+  const observation = registry.get(tokenKey);
+  
+  if (observation && observation.socket) {
+    // Close the associated socket to prevent socket leaks
+    try {
+      observation.socket.close();
+    } catch (err) {
+      // Ignore errors when closing socket
+    }
+  }
   return registry.delete(tokenKey);
+}
+
+/**
+ * Deregisters all observations and closes any associated sockets.
+ * Useful for cleanup during shutdown.
+ */
+function cleanup(clientEp) {
+  for (const [tokenKey, ep, observation] of registry) {
+    if (clientEp == ep && epobservation.socket) {
+      try {
+        observation.socket.close();
+      } catch (err) {
+        // Ignore errors when closing socket
+      }
+    }
+  }
+  registry.clear();
 }
 
 module.exports = {
   registerObservation,
   getObservation,
   deregisterObservation,
+  cleanup
 };

--- a/server/transport/coapClient.js
+++ b/server/transport/coapClient.js
@@ -1,6 +1,6 @@
 // server/transport/coapClient.js
 const crypto = require('crypto');
-const coap = require('coap');
+const coap = require('coap'); //https://github.com/coapjs/node-coap#readme
 const sharedEmitter = require('./sharedEmitter');
 
 /**


### PR DESCRIPTION
server/examples/dtlsServer: uses async/await calls. At least first one should use this mechanism, in order to avoid multiple open sockets
server/examples/server: enables timestamp observation
server/examples/serverMqttGw: uses async/await calls. At least first one should use this mechanism, in order to avoid multiple open sockets
server/observationRegistry: register socket used for observation in case of clean up needed
server/clientRegistry: associateSocket to client
server/resourceClient: if socket is kept open, associate to client
server/transport/coapClientDTLS: reuses socket if already exists to that client (Avoids multiopen sockets)